### PR TITLE
Automatic deployment in dev environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy dev
+on:
+  push:
+    branches:
+      - dev
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy alyx in dev server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.ALYX_HOST }}
+          username: ${{ secrets.ALYX_USERNAME }}
+          key: ${{ secrets.ALYX_KEY }}
+          port: ${{ secrets.ALYX_PORT }}
+          script: | 
+            cd /opt/monadical.alyx
+            ./bin/alyx-deploy


### PR DESCRIPTION
This change add a github action for deploying automatically dev branch in the dev server.
It uses [appleboy/ssh-action](https://github.com/appleboy/ssh-action) to trigger the deployment process in the server.